### PR TITLE
Add circadian lighting to Leo's bedroom

### DIFF
--- a/packages/rooms/bedroom2.yaml
+++ b/packages/rooms/bedroom2.yaml
@@ -23,6 +23,138 @@ automation:
         data: {}
     mode: queued
     max: 10
+  # region Circadian Lighting
+  - id: "1736794523847"
+    alias: "Leo's Bedroom: Apply Circadian Color Temperature"
+    description: "Automatically set color temperature based on sun position when lights turn on"
+    triggers:
+      - trigger: state
+        entity_id:
+          - light.leo_s_bedroom_main_light
+        to: "on"
+        from: "off"
+    conditions:
+      - condition: state
+        entity_id: input_boolean.enable_leos_circadian_lighting
+        state: "on"
+    actions:
+      - choose:
+          # Daytime: Cool/Neutral (sunrise to 1h before sunset)
+          - conditions:
+              - condition: sun
+                after: sunrise
+              - condition: sun
+                before: sunset
+                before_offset: "-01:00:00"
+            sequence:
+              - action: light.turn_on
+                target:
+                  entity_id: light.leo_s_bedroom_main_light
+                data:
+                  color_temp_kelvin: 4500
+                  transition: 1
+
+          # Evening transition: Warm (1h before sunset to 1h after sunset)
+          - conditions:
+              - condition: sun
+                after: sunset
+                after_offset: "-01:00:00"
+              - condition: sun
+                before: sunset
+                before_offset: "01:00:00"
+            sequence:
+              - action: light.turn_on
+                target:
+                  entity_id: light.leo_s_bedroom_main_light
+                data:
+                  color_temp_kelvin: 3200
+                  transition: 1
+
+        # Default: Night/Bedtime - Very warm (1h after sunset to sunrise)
+        default:
+          - action: light.turn_on
+            target:
+              entity_id: light.leo_s_bedroom_main_light
+            data:
+              color_temp_kelvin: 2700
+              transition: 1
+    mode: queued
+    max: 5
+  - id: "1736794524951"
+    alias: "Leo's Bedroom: Scheduled Circadian Transitions"
+    description: "Gradually transition color temperature based on sun position if lights are on"
+    triggers:
+      - trigger: sun
+        event: sunrise
+        id: morning
+      - trigger: sun
+        event: sunset
+        offset: "-01:00:00"
+        id: evening
+      - trigger: sun
+        event: sunset
+        offset: "01:00:00"
+        id: night
+    conditions:
+      - condition: state
+        entity_id: input_boolean.enable_leos_circadian_lighting
+        state: "on"
+      - condition: state
+        entity_id: light.leo_s_bedroom_main_light
+        state: "on"
+    actions:
+      - choose:
+          # Morning: Transition to cool white (4500K) at sunrise
+          - conditions:
+              - condition: trigger
+                id: morning
+            sequence:
+              - action: script.send_to_home_log
+                data:
+                  message: "☀️ Sunrise - Transitioning to daytime color temperature (4500K)"
+                  title: "🛏️ Leo's Bedroom"
+                  log_level: "Debug"
+              - action: light.turn_on
+                target:
+                  entity_id: light.leo_s_bedroom_main_light
+                data:
+                  color_temp_kelvin: 4500
+                  transition: 300
+
+          # Evening: Transition to warm white (3200K) 1h before sunset
+          - conditions:
+              - condition: trigger
+                id: evening
+            sequence:
+              - action: script.send_to_home_log
+                data:
+                  message: "🌆 Pre-sunset - Transitioning to evening color temperature (3200K)"
+                  title: "🛏️ Leo's Bedroom"
+                  log_level: "Debug"
+              - action: light.turn_on
+                target:
+                  entity_id: light.leo_s_bedroom_main_light
+                data:
+                  color_temp_kelvin: 3200
+                  transition: 300
+
+          # Night: Transition to very warm white (2700K) 1h after sunset
+          - conditions:
+              - condition: trigger
+                id: night
+            sequence:
+              - action: script.send_to_home_log
+                data:
+                  message: "🌙 Post-sunset - Transitioning to nighttime color temperature (2700K)"
+                  title: "🛏️ Leo's Bedroom"
+                  log_level: "Debug"
+              - action: light.turn_on
+                target:
+                  entity_id: light.leo_s_bedroom_main_light
+                data:
+                  color_temp_kelvin: 2700
+                  transition: 600
+    mode: single
   # region Blinds
   - id: "1627285063813"
     alias: "Leo's Bedroom: Timed Open Blinds Weekday"


### PR DESCRIPTION
## Summary

Implements automated color temperature changes based on sun position for Leo's bedroom lights to support natural sleep/wake cycles and healthy circadian rhythm.

**Key Features:**
- Automatically adjusts light color temperature when lights turn on
- Scheduled gradual transitions at sunrise and sunset
- Seasonal awareness: automatically adjusts throughout the year
- Cool white (4500K) during daytime
- Warm white (3200K) during evening transition  
- Very warm (2700K) at night
- Enable/disable toggle for flexibility

## Changes

Added two automations to `packages/rooms/bedroom2.yaml`:

1. **Apply Circadian Color Temperature** (ID: 1736794523847)
   - Triggers when lights turn on
   - Sets appropriate color temp based on current sun position
   - Immediate application (1 second transition)
   - Queued mode handles rapid toggles

2. **Scheduled Circadian Transitions** (ID: 1736794524951)
   - Triggers at sunrise, sunset-1h, and sunset+1h
   - Gradually transitions if lights already on
   - 5-minute transitions during day/evening
   - 10-minute transition at night (gentler for sleep prep)

## Implementation Details

### Color Temperature Schedule
- **Sunrise to Sunset-1h**: 4500K cool white (alertness, homework)
- **Sunset-1h to Sunset+1h**: 3200K warm white (transition period)
- **Sunset+1h to Sunrise**: 2700K very warm (sleep prep, melatonin)

### Sun-Based Advantages
- Winter: Automatic earlier warm lighting (shorter days)
- Summer: Automatic later warm lighting (longer days)
- No manual schedule adjustments needed
- More natural circadian alignment

### User Control
- Enable/disable toggle: `input_boolean.enable_leos_circadian_lighting`
- Respects manual color changes until next scheduled transition
- No forced overrides, only applies on light turn-on or scheduled times

## Testing Required

1. **Create helper toggle in UI:**
   - Settings → Devices & Services → Helpers
   - Create Toggle: `enable_leos_circadian_lighting`
   - Optional name: "Leo's Circadian Lighting"

2. **Test light turn-on at different times:**
   - Daytime: Should turn on cool white (4500K)
   - Evening: Should turn on warm white (3200K)
   - Night: Should turn on very warm (2700K)

3. **Test scheduled transitions:**
   - Turn lights on before sunrise, watch morning transition
   - Turn lights on before sunset-1h, watch evening transition
   - Verify smooth 5-10 minute gradual changes

4. **Test manual override:**
   - Manually set lights to blue
   - Verify next scheduled transition changes color back to circadian

## Design Rationale

**Why sun-based instead of fixed times?**
- Respects natural daylight changes throughout the year
- No need to adjust automation times seasonally
- More aligned with circadian rhythm science
- Sunrise/sunset varies by 2+ hours between seasons

**Why two automations?**
- On-demand (immediate) color when lights first turn on
- Scheduled (gradual) transitions if lights already on
- Prevents wrong color at light turn-on
- Prevents jarring changes for already-on lights

**Why queued + single modes?**
- Automation 1: `queued max:5` handles rapid light toggles
- Automation 2: `single` prevents overlapping transitions
- Respects user interaction patterns

## Related

Implements Feature 7 from bedroom2.yaml review (circadian lighting)