### PR TITLE
docs: fix stale READMEs - bathroom switch migration, office/conservatory automations

### DIFF
--- a/packages/rooms/bathroom_README.md
+++ b/packages/rooms/bathroom_README.md
@@ -15,7 +15,7 @@ flowchart TB
         LIGHT_LEVEL[Light Level\nsensor.bathroom_area_mean_light_level]
         HUMIDITY[Humidity\nsensor.bathroom_motion_humidity]
         TEMP[Door Temperature\nsensor.bathroom_door_temperature]
-        SWITCH[Light Switch\nbinary_sensor.bathroom_light_input_0]
+        SWITCH[Light Switch\nbinary_sensor.bathroom_switch_input_0]
     end
 
     subgraph Logic["⚙️ Logic"]
@@ -73,7 +73,7 @@ The lighting system uses a sophisticated decision tree:
 
 ### Humidity & Mold Prevention
 
-- **High Humidity Alert**: Triggers when humidity > 59.9% for 30+ minutes with door/window closed
+- **High Humidity Alert**: Triggers when humidity > 59.9% for 1+ minute with door/window closed
 - **Mold Indicator**: Calculates mold risk based on indoor humidity, indoor temperature, and outdoor temperature
 
 ### Toothbrush Integration
@@ -138,7 +138,7 @@ No Motion Detected
 |-----------|-------|
 | **ID** | `1754254675073` |
 | **Trigger** | Wall switch input changes |
-| **Entity** | `binary_sensor.bathroom_light_input_0` |
+| **Entity** | `binary_sensor.bathroom_switch_input_0` |
 | **Action** | If lights turned on manually, cancel auto-off timer |
 
 ### Bathroom: Light Timer Finished
@@ -163,9 +163,18 @@ No Motion Detected
 | Attribute | Value |
 |-----------|-------|
 | **ID** | `1680461746985` |
-| **Trigger** | Humidity > 59.9% for 30 minutes |
+| **Trigger** | Humidity > 59.9% for 1 minute |
 | **Conditions** | Window closed AND door closed |
 | **Action** | Send notification to Danny & Terina |
+
+### Bathroom: Light On For Long Time And Fan Off
+
+| Attribute | Value |
+|-----------|-------|
+| **ID** | `1777131323273` |
+| **Trigger** | `switch.bathroom_lights_2` on for 5+ minutes |
+| **Conditions** | Fan switch (`switch.bathroom_fan_2`) is `off` AND automations enabled |
+| **Action** | Turn on fan (`switch.bathroom_fan_2`) + log event |
 
 ### Bathroom: Danny's Toothbrush
 
@@ -224,7 +233,7 @@ Calculates mold risk based on:
 | `binary_sensor.bathroom_area_motion` | Aggregated area motion |
 | `binary_sensor.bathroom_door_contact` | Door contact sensor |
 | `binary_sensor.bathroom_window_contact` | Window contact sensor |
-| `binary_sensor.bathroom_light_input_0` | Wall switch input |
+| `binary_sensor.bathroom_switch_input_0` | Wall switch input |
 
 ### Sensors
 

--- a/packages/rooms/bathroom_README.md
+++ b/packages/rooms/bathroom_README.md
@@ -24,7 +24,7 @@ flowchart TB
     end
 
     subgraph Outputs["💡 Outputs"]
-        LIGHTS[Bathroom Lights\nlight.bathroom_lights]
+        LIGHTS[Bathroom Lights\nswitch.bathroom_lights_2]
     end
 
     subgraph External["🔗 External"]
@@ -149,6 +149,15 @@ No Motion Detected
 | **Trigger** | `timer.bathroom_light_off` finishes |
 | **Action** | Turn off lights + log event |
 
+### Bathroom: Fan Auto-Off (Low Humidity)
+
+| Attribute | Value |
+|-----------|-------|
+| **Type** | Sub-automation (choice branch) |
+| **Trigger** | `switch.bathroom_light_2` turns `off` |
+| **Conditions** | Fan switch (`switch.bathroom_fan_2`) is `on` AND humidity < 60% |
+| **Action** | Turn off fan (`switch.bathroom_fan`) + log event |
+
 ### Bathroom: High Humidity
 
 | Attribute | Value |
@@ -232,7 +241,7 @@ Calculates mold risk based on:
 
 | Entity | Description |
 |--------|-------------|
-| `light.bathroom_lights` | Main bathroom light group |
+| `switch.bathroom_lights_2` | Main bathroom light switch |
 | `light.bathroom` | Individual bathroom light (for flashing) |
 
 ### Input Helpers

--- a/packages/rooms/conservatory/README.md
+++ b/packages/rooms/conservatory/README.md
@@ -298,6 +298,20 @@ Turns off the airer when schedule ends.
 - Log message
 - Turn off `switch.airer`
 
+### Temperature
+
+#### Conservatory: Cold Temperature
+**ID:** `1674478124534`
+
+Triggers heating boost when temperature falls below 3°C.
+
+**Triggers:**
+- `sensor.conservatory_area_mean_temperature` drops below 3°C
+
+**Actions:**
+- Set climate preset to `boost`
+- Log message: "Conservatory fell below 3c. Boosting central heating."
+
 ---
 
 ### 3D Printer

--- a/packages/rooms/office/README.md
+++ b/packages/rooms/office/README.md
@@ -595,22 +595,6 @@ MQTT remote control for fan.
 
 ---
 
-#### Office: Front Door Status On For Long Time
-**ID:** `1743186662871`
-
-Turns off office light if front door has been closed for 3 minutes.
-
-**Triggers:**
-- `light.office_light` on for 3 minutes
-
-**Conditions:**
-- Front door is closed (`off`)
-
-**Actions:**
-- Turns off `light.office_light`
-
----
-
 ### Utilities
 
 The package includes various utility automations for device management and notifications.


### PR DESCRIPTION
## Summary

Fixes documentation inconsistencies discovered by reviewing the last 10 commits.

### Changes

| Package | Fix |
|---------|-----|
| bathroom | Updated entity references from  →  (matches ea961cf0) |
| bathroom | Added missing "Fan Auto-Off (Low Humidity)" sub-automation |
| office | Removed stale automation "Front Door Status On For Long Time" (was deleted in 9bb535be) |
| conservatory | Added missing "Cold Temperature" automation (moved from scene to automation in c0e3fe5d) |

### Verification

- Bathroom:  now documented in entity table and flowchart
- Office: Removed automation ID  which no longer exists in YAML
- Conservatory: Added automation with trigger 

---

Please review and merge. ⚠️ Note: this updates 3 README files.